### PR TITLE
Mark source_lang parameter optional to detect language

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ git clone https://github.com/sharplab/deepl4j
         try {
             Translations response = deepLApi.translate(
                     Collections.singletonList("This is a pen."),
-                    "EN",
                     "JA",
+                    null, //null to detect source_lang
                     null,
                     null,
                     null,

--- a/src/main/resources/specs/deepl-api-v2.yml
+++ b/src/main/resources/specs/deepl-api-v2.yml
@@ -26,7 +26,6 @@ paths:
               type: object
               required:
                 - text
-                - source_lang
                 - target_lang
               properties:
                 text:
@@ -180,7 +179,7 @@ paths:
               - "SV" # Swedish
               - "ZH" # Chinese
         - name: target_lang
-          required: false
+          required: true
           in: query
           schema:
             type: string

--- a/src/test/java/integration/net/sharplab/deepl4j/DeepLApiTest.java
+++ b/src/test/java/integration/net/sharplab/deepl4j/DeepLApiTest.java
@@ -31,8 +31,8 @@ public class DeepLApiTest {
         try{
             Translations response = target.translateTexts(
                     Arrays.asList("This is a pen.", "This is an apple."),
-                    "EN",
                     "JA",
+                    null,
                     null,
                     null,
                     null,


### PR DESCRIPTION
Make `source_lang` parameter optional

**Breaking Change**

Since `source_lang` parameter become optional, the position of `source_lang` and `target_lange` parameter in the `translateTexts` method parameters are inverted. Existing code calling the `translateTexts` method need to be updated.
